### PR TITLE
fix socket.io not connecting to the right url path

### DIFF
--- a/src/jvmMain/kotlin/chat/sphinx/features/socket_io/SocketIOManagerImpl.kt
+++ b/src/jvmMain/kotlin/chat/sphinx/features/socket_io/SocketIOManagerImpl.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
+import java.net.URI
 import java.util.concurrent.TimeUnit
 import kotlin.jvm.Volatile
 
@@ -252,6 +253,7 @@ class SocketIOManagerImpl(
             .build()
 
         val options: IO.Options = IO.Options().apply {
+            path = URI(nnRelayData.third.value + "/socket.io").getRawPath()
             callFactory = client
             webSocketFactory = client
             reconnection = true

--- a/src/jvmMain/kotlin/chat/sphinx/features/socket_io/SocketIOManagerImpl.kt
+++ b/src/jvmMain/kotlin/chat/sphinx/features/socket_io/SocketIOManagerImpl.kt
@@ -252,8 +252,11 @@ class SocketIOManagerImpl(
             .writeTimeout(0L, TimeUnit.SECONDS)
             .build()
 
+        val socketURI = URI(nnRelayData.third.value + "/socket.io")
+        val socketURL = socketURI.toURL()
+
         val options: IO.Options = IO.Options().apply {
-            path = URI(nnRelayData.third.value + "/socket.io").getRawPath()
+            path = socketURI.getRawPath()
             callFactory = client
             webSocketFactory = client
             reconnection = true
@@ -270,7 +273,7 @@ class SocketIOManagerImpl(
         val socket: Socket = try {
             // TODO: Need to add listener to relayData in case it is changed
             //  need to disconnect and open a new socket.
-            IO.socket(nnRelayData.third.value, options)
+            IO.socket(socketURL.getProtocol() + "://" + socketURL.getAuthority(), options)
         } catch (e: Exception) {
             val msg = "Failed to create socket-io instance"
             LOG.e(TAG, msg, e)


### PR DESCRIPTION
i have my relay behind an apache2 proxy
example:
relay at localhost:3000
example.com/sphinx proxied to localhost:3000
relay url in the app: example.com/sphinx
all requests work except socketio, that tried to connect to example.com/socket.io, but has to connect to example.com/sphinx/socket.io to get through the proxy and end up at localhost:3000/socket.io
i fixed this by adding a path option to socket io. it takes the path from the relay url

tested with the desktop app (sphinx-kotlin-ui) at aed9a646e4a26de0539f530c2edb7e47404ff0ec