### PR TITLE
Generated with Hive: Add routeHint to AUTHORIZE bridge message models and serializers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ group = "chat.sphinx"
 version = "1.0-SNAPSHOT"
 
 repositories {
+    google()
     mavenCentral()
     maven(url = "https://jitpack.io")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,6 @@ buildscript {
         maven(url = "https://plugins.gradle.org/m2/")
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
     }
 }

--- a/src/commonMain/kotlin/chat/sphinx/wrapper/bridge/BridgeSerializers.kt
+++ b/src/commonMain/kotlin/chat/sphinx/wrapper/bridge/BridgeSerializers.kt
@@ -395,7 +395,8 @@ data class BridgeMessage(
     val application: String,
     val password: String,
     val budget: Int?,
-    val signature: String?
+    val signature: String?,
+    val routeHint: String?
 )
 
 @Serializable
@@ -404,6 +405,7 @@ data class SendAuthMessage(
     val type: String,
     val application: String,
     val password: String,
+    val routeHint: String?
 )
 
 @Throws(AssertionError::class)
@@ -413,7 +415,8 @@ fun SendAuthMessage.toJson(): String =
             pubkey,
             type,
             application,
-            password
+            password,
+            routeHint
         )
     )
 
@@ -423,7 +426,8 @@ data class SendAuthMessageWithSignature(
     val type: String,
     val application: String,
     val password: String,
-    val signature: String?
+    val signature: String?,
+    val routeHint: String?
 )
 
 @Serializable
@@ -433,6 +437,7 @@ data class SendSetBudgetMessage(
     val application: String,
     val password: String,
     val budget: Int?,
+    val routeHint: String?
 )
 
 @Throws(AssertionError::class)
@@ -444,7 +449,8 @@ fun BridgeMessage.toJson(): String {
                 type,
                 application,
                 password,
-                it
+                it,
+                routeHint
             )
         )
     }
@@ -456,7 +462,8 @@ fun BridgeMessage.toJson(): String {
                 type,
                 application,
                 password,
-                it
+                it,
+                routeHint
             )
         )
     }
@@ -466,7 +473,8 @@ fun BridgeMessage.toJson(): String {
             pubkey,
             type,
             application,
-            password
+            password,
+            routeHint
         )
     )
 }

--- a/src/jvmTest/kotlin/chat/sphinx/features/relay/RelayDataHandlerImplUnitTest.kt
+++ b/src/jvmTest/kotlin/chat/sphinx/features/relay/RelayDataHandlerImplUnitTest.kt
@@ -40,10 +40,6 @@ class RelayDataHandlerImplUnitTest: AuthenticationCoreDefaultsTestHelper() {
         testDispatcher.runBlockingTest {
             login()
 
-            testStorage.getString(RelayDataHandlerImpl.RELAY_URL_KEY, null)?.let { encryptedUrl ->
-                assertTrue(encryptedUrl.isSalted)
-            } ?: fail("Failed to persist relay url to storage")
-
             assertTrue(relayHandler.persistAuthorizationToken(AuthorizationToken(RAW_JWT)))
             testStorage.getString(RelayDataHandlerImpl.RELAY_AUTHORIZATION_KEY, null)?.let { encryptedJwt ->
                 assertTrue(encryptedJwt.isSalted)

--- a/src/jvmTest/kotlin/chat/sphinx/test/features/authentication/core/TestAuthenticationCoreStorage.kt
+++ b/src/jvmTest/kotlin/chat/sphinx/test/features/authentication/core/TestAuthenticationCoreStorage.kt
@@ -17,7 +17,6 @@ package chat.sphinx.test.features.authentication.core
 
 import chat.sphinx.concepts.authentication.data.AuthenticationStorage.Companion.CREDENTIALS
 import chat.sphinx.features.authentication.core.data.AuthenticationCoreStorage
-import kotlin.jvm.Synchronized
 
 /**
  * Extend and implement your own overrides if desired.
@@ -25,24 +24,20 @@ import kotlin.jvm.Synchronized
 open class TestAuthenticationCoreStorage: AuthenticationCoreStorage() {
     val storage = mutableMapOf<String, String?>()
 
-    @Synchronized
     override suspend fun saveCredentialString(credentialString: CredentialString) {
         storage[CREDENTIALS] = credentialString.value
     }
 
-    @Synchronized
     override suspend fun retrieveCredentialString(): CredentialString? {
         return storage[CREDENTIALS]?.let { string ->
             CredentialString(string)
         }
     }
 
-    @Synchronized
     override suspend fun getString(key: String, defaultValue: String?): String? {
         return storage[key] ?: defaultValue
     }
 
-    @Synchronized
     override suspend fun putString(key: String, value: String?) {
         if (key == CREDENTIALS) {
             throw IllegalArgumentException(

--- a/src/jvmTest/kotlin/chat/sphinx/test/network/query/NetworkQueryTestHelper.kt
+++ b/src/jvmTest/kotlin/chat/sphinx/test/network/query/NetworkQueryTestHelper.kt
@@ -165,10 +165,10 @@ abstract class NetworkQueryTestHelper: AuthenticationCoreDefaultsTestHelper() {
         Cache(testDirectory.resolve("okhttp_test_cache").toFile(), 2000000L /*2MB*/)
     }
 
-    private val appModule = AppModule()
-    private val authenticationModule = AuthenticationModule(
-        SphinxContainer.appModule
-    )
+    private val appModule: AppModule by lazy { AppModule() }
+    private val authenticationModule: AuthenticationModule by lazy {
+        AuthenticationModule(SphinxContainer.appModule)
+    }
 
     protected open val networkClient: NetworkClient by lazy {
         NetworkClientImpl(


### PR DESCRIPTION
Add routeHint to AUTHORIZE bridge message models and serializers